### PR TITLE
Add options hash for optional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 ## Twitch Class
 
 ### Starting
-The class object takes two parameters in the object, the client ID and the client secret.  
-Create the a new object with the correct parameters to use the class.  
+The class object takes two parameters in the object, the client ID and the client secret.
+Create the a new object with the correct parameters to use the class.
 
 The package [dotenv](https://github.com/motdotla/dotenv) is recommended for keeping your client information secret.
 ```js
@@ -21,9 +21,9 @@ const twitch = new Twitch({
 | METHOD  | DESCRIPTION |
 |:--------:|:-----------:|
 | `.getUser(user)` | Returns information about a user |
-| `.getFeaturedStreams()` | Returns twitch's featured streams |
-| `.getTopStreams()`      | Returns the current top streams |
-| `.getTopGames()`        | Returns the top games |
+| `.getFeaturedStreams(options)` | Returns twitch's featured streams |
+| `.getTopStreams(options)`      | Returns the current top streams |
+| `.getTopGames(options)`        | Returns the top games |
 | `.getUsersByGame(game)`  |  Returns users by game |
 | `.getStreamUrl(user)`    | Returns the RTMP stream URL |
 | `.searchChannels(query, limit, offset)` | Returns a list of channels |
@@ -42,6 +42,24 @@ const twitch = new Twitch({
 });
 
 twitch.getUser("idietmoran")
+    .then(data => {
+        console.log(data);
+    })
+    .catch(error => {
+        console.error(error);
+    });
+
+// making requests with optional parameters
+const optionalParams = {game: 'StarCraft: Brood War', language: 'es'};
+twitch.getTopStreams(optionalParams)
+    .then(data => {
+        console.log(data);
+    })
+    .catch(error => {
+        console.error(error);
+    });
+
+twitch.getFeaturedStreams({limit: 5})
     .then(data => {
         console.log(data);
     })

--- a/src/twitch.js
+++ b/src/twitch.js
@@ -78,12 +78,12 @@ TwitchCtrl.prototype.getFeaturedStreams = function() {
 * @param {String} options.language : only shows streams of a certain language. Permitted values are locale ID strings, e.g. {en}, {fi}, {es-mx}
 * @returns {Promise.<string, Error>} : resolves JSON data or rejects an error
 */
-TwitchCtrl.prototype.getTopStreams = function(options = null) {
+TwitchCtrl.prototype.getTopStreams = function(options) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
         let url = "https://api.twitch.tv/kraken/games/top";
 
-        if(!options) {
+        if(options) {
             _buildOptions(options, function(data) => {
                 url += data;
             })
@@ -105,12 +105,12 @@ TwitchCtrl.prototype.getTopStreams = function(options = null) {
 * @param {Integer} options.offset : object offset for pagination {Default: 0}
 * @returns {Promise.<string, Error>} : resolves JSON data or rejects an error
 */
-TwitchCtrl.prototype.getTopGames = function(options = null) {
+TwitchCtrl.prototype.getTopGames = function(options) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
         let url = "https://api.twitch.tv/kraken/games/top";
 
-        if(!options) {
+        if(options) {
             _buildOptions(options, function(data) => {
                 url += data;
             })

--- a/src/twitch.js
+++ b/src/twitch.js
@@ -53,11 +53,10 @@ TwitchCtrl.prototype.getUser = function(username) {
 * @param {Integer} options.offset : object offset for pagination {Default: 0}
 * @returns {Promise.<string, Error>} : resolve JSON data or rejects an error
 */
-TwitchCtrl.prototype.getFeaturedStreams = function(options) {
+TwitchCtrl.prototype.getFeaturedStreams = function() {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
         let url = "https://api.twitch.tv/kraken/streams/featured"
-        url += _buildOptions(options);
         // make our request
         this.makeRequest(url)
             .then(data => {
@@ -79,11 +78,16 @@ TwitchCtrl.prototype.getFeaturedStreams = function(options) {
 * @param {String} options.language : only shows streams of a certain language. Permitted values are locale ID strings, e.g. {en}, {fi}, {es-mx}
 * @returns {Promise.<string, Error>} : resolves JSON data or rejects an error
 */
-TwitchCtrl.prototype.getTopStreams = function(options) {
+TwitchCtrl.prototype.getTopStreams = function(options = null) {
     return new Promise((resolve, reject) => {
-            // set our URL for working with the api
-            let url = "https://api.twitch.tv/kraken/streams"
-            url += _buildOptions(options);
+        // set our URL for working with the api
+        let url = "https://api.twitch.tv/kraken/games/top";
+
+        if(!options) {
+            _buildOptions(options, function(data) => {
+                url += data;
+            })
+        }
             // make our request
             this.makeRequest(url)
                 .then(data => {
@@ -101,11 +105,17 @@ TwitchCtrl.prototype.getTopStreams = function(options) {
 * @param {Integer} options.offset : object offset for pagination {Default: 0}
 * @returns {Promise.<string, Error>} : resolves JSON data or rejects an error
 */
-TwitchCtrl.prototype.getTopGames = function(options) {
+TwitchCtrl.prototype.getTopGames = function(options = null) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
-        let url = "https://api.twitch.tv/kraken/games/top"
-        url += _buildOptions(options);
+        let url = "https://api.twitch.tv/kraken/games/top";
+
+        if(!options) {
+            _buildOptions(options, function(data) => {
+                url += data;
+            })
+        }
+
         // make our request
         this.makeRequest(url)
             .then(data => {
@@ -124,7 +134,13 @@ TwitchCtrl.prototype.getTopGames = function(options) {
 TwitchCtrl.prototype.getUsersByGame = function(game) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
-        let url = `https://api.twitch.tv/kraken/streams/?game=${game}`;
+        let url = "https://api.twitch.tv/kraken/games/top";
+
+        if(!options) {
+            _buildOptions(options, function(data) => {
+                url += data;
+            })
+        }
         // make our request
         this.makeRequest(url)
             .then(data => {
@@ -227,15 +243,13 @@ TwitchCtrl.prototype.searchGames = function(query, type = 'suggest', live = true
     });
 }
 
-function _buildOptions(options) {
-    if(!options) return '';
-
-    return Object.keys(options).reduce((params, option, index) => {
+function _buildOptions(options, callback) {
+    Object.keys(options).reduce((params, option, index) => {
         const encodedParam = `${encodeURIComponent(option)}=${encodeURIComponent(options[option])}`;
         if(index === 0) {
-            return `?${encodedParam}`;
+            return callback(`?${encodedParam}`);
         }
-        return `${params}&${encodedParam}`;
+        return callback(`${params}&${encodedParam}`);
     }, '');
 }
 

--- a/src/twitch.js
+++ b/src/twitch.js
@@ -134,13 +134,7 @@ TwitchCtrl.prototype.getTopGames = function(options) {
 TwitchCtrl.prototype.getUsersByGame = function(game) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
-        let url = "https://api.twitch.tv/kraken/games/top";
-
-        if(!options) {
-            _buildOptions(options, function(data) => {
-                url += data;
-            })
-        }
+        let url = `https://api.twitch.tv/kraken/streams/?game=${game}`;
         // make our request
         this.makeRequest(url)
             .then(data => {

--- a/src/twitch.js
+++ b/src/twitch.js
@@ -243,13 +243,13 @@ TwitchCtrl.prototype.searchGames = function(query, type = 'suggest', live = true
 }
 
 function _buildOptions(options, callback) {
-    Object.keys(options).reduce((params, option, index) => {
+    callback(Object.keys(options).reduce((params, option, index) => {
         const encodedParam = `${encodeURIComponent(option)}=${encodeURIComponent(options[option])}`;
         if(index === 0) {
-            return callback(`?${encodedParam}`);
+            return `?${encodedParam}`;
         }
-        return callback(`${params}&${encodedParam}`);
-    }, '');
+        return `${params}&${encodedParam}`;
+    }, ''));
 }
 
 module.exports = TwitchCtrl;

--- a/src/twitch.js
+++ b/src/twitch.js
@@ -53,10 +53,15 @@ TwitchCtrl.prototype.getUser = function(username) {
 * @param {Integer} options.offset : object offset for pagination {Default: 0}
 * @returns {Promise.<string, Error>} : resolve JSON data or rejects an error
 */
-TwitchCtrl.prototype.getFeaturedStreams = function() {
+TwitchCtrl.prototype.getFeaturedStreams = function(options) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
         let url = "https://api.twitch.tv/kraken/streams/featured"
+        if(options) {
+            _buildOptions(options, data => {
+                url += data;
+            })
+        }
         // make our request
         this.makeRequest(url)
             .then(data => {
@@ -81,10 +86,10 @@ TwitchCtrl.prototype.getFeaturedStreams = function() {
 TwitchCtrl.prototype.getTopStreams = function(options) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
-        let url = "https://api.twitch.tv/kraken/games/top";
+        let url = "https://api.twitch.tv/kraken/streams";
 
         if(options) {
-            _buildOptions(options, function(data) => {
+            _buildOptions(options, data => {
                 url += data;
             })
         }
@@ -111,7 +116,7 @@ TwitchCtrl.prototype.getTopGames = function(options) {
         let url = "https://api.twitch.tv/kraken/games/top";
 
         if(options) {
-            _buildOptions(options, function(data) => {
+            _buildOptions(options, data => {
                 url += data;
             })
         }

--- a/src/twitch.js
+++ b/src/twitch.js
@@ -27,7 +27,6 @@ TwitchCtrl.prototype.makeRequest = function(http) {
     });
 }
 
-
 /**
 * @description : gets user data from the api
 * @param {String} username : the username we want information from
@@ -49,12 +48,16 @@ TwitchCtrl.prototype.getUser = function(username) {
 
 /**
 * @description : Gets featured streams
+* @param {Hash} options : optional query params
+* @param {Integer} options.limit : maximum number of objects in array {Default: 25} {Maximum: 100}
+* @param {Integer} options.offset : object offset for pagination {Default: 0}
 * @returns {Promise.<string, Error>} : resolve JSON data or rejects an error
 */
-TwitchCtrl.prototype.getFeaturedStreams = function() {
+TwitchCtrl.prototype.getFeaturedStreams = function(options) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
         let url = "https://api.twitch.tv/kraken/streams/featured"
+        url += _buildOptions(options);
         // make our request
         this.makeRequest(url)
             .then(data => {
@@ -66,12 +69,21 @@ TwitchCtrl.prototype.getFeaturedStreams = function() {
 
 /**
 * @description : Makes an api call to retrieve all top streams on twitch
+* @param {Hash} options : optional query params
+* @param {String} options.game : streams categorized under {game}
+* @param {String} options.channel : streams from a comma separated list of channels
+* @param {Integer} options.limit : maximum number of objects in array {Default: 25} {Maximum: 100}
+* @param {Integer} options.offset : object offset for pagination {Default: 0}
+* @param {Integer} options.client_id : only shows streams from applications of {client_id}
+* @param {String} options.stream_type : only shows streams from a certain type. Permitted values: {all}, {playlist}, {live}
+* @param {String} options.language : only shows streams of a certain language. Permitted values are locale ID strings, e.g. {en}, {fi}, {es-mx}
 * @returns {Promise.<string, Error>} : resolves JSON data or rejects an error
 */
-TwitchCtrl.prototype.getTopStreams = function() {
+TwitchCtrl.prototype.getTopStreams = function(options) {
     return new Promise((resolve, reject) => {
             // set our URL for working with the api
             let url = "https://api.twitch.tv/kraken/streams"
+            url += _buildOptions(options);
             // make our request
             this.makeRequest(url)
                 .then(data => {
@@ -84,12 +96,16 @@ TwitchCtrl.prototype.getTopStreams = function() {
 
 /**
 * @description : Makes an API call to top games on twitch
+* @param {Hash} options : optional query params
+* @param {Integer} options.limit : maximum number of objects in array {Default: 25} {Maximum: 100}
+* @param {Integer} options.offset : object offset for pagination {Default: 0}
 * @returns {Promise.<string, Error>} : resolves JSON data or rejects an error
 */
-TwitchCtrl.prototype.getTopGames = function() {
+TwitchCtrl.prototype.getTopGames = function(options) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
         let url = "https://api.twitch.tv/kraken/games/top"
+        url += _buildOptions(options);
         // make our request
         this.makeRequest(url)
             .then(data => {
@@ -209,6 +225,18 @@ TwitchCtrl.prototype.searchGames = function(query, type = 'suggest', live = true
             })
             .catch(reject);
     });
+}
+
+function _buildOptions(options) {
+    if(!options) return '';
+
+    return Object.keys(options).reduce((params, option, index) => {
+        const encodedParam = `${encodeURIComponent(option)}=${encodeURIComponent(options[option])}`;
+        if(index === 0) {
+            return `?${encodedParam}`;
+        }
+        return `${params}&${encodedParam}`;
+    }, '');
 }
 
 module.exports = TwitchCtrl;


### PR DESCRIPTION
Hey, I added the ability for users to add a options hash to send with the request to make their calls more specific

I wanted a way to specify the optional query params that are detained in the api. [Example for GET /streams](https://dev.twitch.tv/docs/v3/reference/streams/#get-streams)