### PR TITLE
use querystring module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+test/

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 README.md
 .gitignore
 node_modules/
+test/

--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ twitch.getTopStreams()
     .catch(function(error) {
         console.error(error);
     });
+
+// using async/await
+async function foo() {
+    let data = await twitch.getTopStreams();
+    console.log(data);
+}
+
+// with error handling
+async function foo() {
+    try {
+        let data = await twitch.getTopStreams();
+        console.log(data);
+    } catch(err) {
+        throw err;
+    }
+}
 ```
 
 ### Example

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twitch.tv-api",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "dependencies": {
     "bluebird": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "twitch.tv-api",
+  "version": "1.2.2",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "bluebird": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+    },
+    "dotenv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitch.tv-api",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "easy node interaction with the twitch api, with promises",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitch.tv-api",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "easy node interaction with the twitch api, with promises",
   "main": "index.js",
   "scripts": {
@@ -19,5 +19,8 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.5.0"
+  },
+  "devDependencies": {
+    "dotenv": "^4.0.0"
   }
 }

--- a/src/twitch.js
+++ b/src/twitch.js
@@ -1,12 +1,13 @@
 const request = require('./bin/request.js');
 const url = require('url');
 const Promise = require('bluebird');
+const qs = require('querystring');
 
 /**
 * @description : Creates our twitch class
 * @param {Object<id, secret>} options : pases our client id and secret to the constructor
 */
-function TwitchCtrl(options) {
+function Twitch(options) {
     this.id = options.id;
     this.secret = options.secret;
 }
@@ -16,7 +17,7 @@ function TwitchCtrl(options) {
 * @param {String} http : passes an string to our request
 * @returns {Promise.<string, Error>} returns data from an http request;
 */
-TwitchCtrl.prototype.makeRequest = function(http) {
+Twitch.prototype.makeRequest = function(http) {
     return new Promise((resolve, reject) => {
         // set the headers in our request
             let headers = {
@@ -35,7 +36,7 @@ TwitchCtrl.prototype.makeRequest = function(http) {
 * @param {String} username : the username we want information from
 * @returns {Promise.<string, Error>} : resolves JSON data or rejects an error
 */
-TwitchCtrl.prototype.getUser = function(username) {
+Twitch.prototype.getUser = function(username) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
         let url = `https://api.twitch.tv/kraken/streams/${username}`;
@@ -56,14 +57,12 @@ TwitchCtrl.prototype.getUser = function(username) {
 * @param {Integer} options.offset : object offset for pagination {Default: 0}
 * @returns {Promise.<string, Error>} : resolve JSON data or rejects an error
 */
-TwitchCtrl.prototype.getFeaturedStreams = function(options) {
+Twitch.prototype.getFeaturedStreams = function(options) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
         let url = "https://api.twitch.tv/kraken/streams/featured"
         if(options) {
-            _buildOptions(options, data => {
-                url += data;
-            })
+            url += `?${qs.stringify(optionalParams, '&', '=')}`;
         }
         // make our request
         this.makeRequest(url)
@@ -85,15 +84,13 @@ TwitchCtrl.prototype.getFeaturedStreams = function(options) {
 * @param {Integer} options.offset : object offset for pagination {Default: 0}
 * @returns {Promise.<string, Error>} : resolves JSON data or rejects an error
 */
-TwitchCtrl.prototype.getTopStreams = function(options) {
+Twitch.prototype.getTopStreams = function(options) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
         let url = "https://api.twitch.tv/kraken/streams";
 
         if(options) {
-            _buildOptions(options, data => {
-                url += data;
-            })
+            url += `?${qs.stringify(optionalParams, '&', '=')}`;
         }
             // make our request
             this.makeRequest(url)
@@ -112,15 +109,13 @@ TwitchCtrl.prototype.getTopStreams = function(options) {
 * @param {Integer} options.offset : object offset for pagination {Default: 0}
 * @returns {Promise.<string, Error>} : resolves JSON data or rejects an error
 */
-TwitchCtrl.prototype.getTopGames = function(options) {
+Twitch.prototype.getTopGames = function(options) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
         let url = "https://api.twitch.tv/kraken/games/top";
 
         if(options) {
-            _buildOptions(options, data => {
-                url += data;
-            })
+            url += `?${qs.stringify(optionalParams, '&', '=')}`;
         }
 
         // make our request
@@ -138,7 +133,7 @@ TwitchCtrl.prototype.getTopGames = function(options) {
 * @param {String} game : the game we want to search
 * @returns {Promise.<string, Error>} : resolves JSON data or rejects an error
 */
-TwitchCtrl.prototype.getUsersByGame = function(game) {
+Twitch.prototype.getUsersByGame = function(game) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
         let url = `https://api.twitch.tv/kraken/streams/?game=${game}`;
@@ -157,7 +152,7 @@ TwitchCtrl.prototype.getUsersByGame = function(game) {
 * @param {String} user : the user we want to search
 * @returns {Promise.<string, Error>} : resolves link
 */
-TwitchCtrl.prototype.getStreamUrl = function(user) {
+Twitch.prototype.getStreamUrl = function(user) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
         user = user.toLowerCase();
@@ -185,7 +180,7 @@ TwitchCtrl.prototype.getStreamUrl = function(user) {
 * @param {Integer} offset : object offset for pagination of results {Default: 0}
 * @returns {Promise.<string, Error>} : resolves JSON data or rejects an error
 */
-TwitchCtrl.prototype.searchChannels = function(query, limit = 25, offset = 0) {
+Twitch.prototype.searchChannels = function(query, limit = 25, offset = 0) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
         query = encodeURIComponent(query);
@@ -207,7 +202,7 @@ TwitchCtrl.prototype.searchChannels = function(query, limit = 25, offset = 0) {
 * @param {Integer} offset : object offset for pagination of results {Default: 0}
 * @returns {Promise.<string, Error>} : resolves JSON data or rejects an error
 */
-TwitchCtrl.prototype.searchStreams = function(query, limit = 25, offset = 0) {
+Twitch.prototype.searchStreams = function(query, limit = 25, offset = 0) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
         query = encodeURIComponent(query);
@@ -228,7 +223,7 @@ TwitchCtrl.prototype.searchStreams = function(query, limit = 25, offset = 0) {
 * @param {Boolean} live : if true, only returns games that are live on at least one channel  {Default: false}
 * @returns {Promise.<string, Error>} : resolves JSON data or rejects an error
 */
-TwitchCtrl.prototype.searchGames = function(query, live = false) {
+Twitch.prototype.searchGames = function(query, live = false) {
     return new Promise((resolve, reject) => {
         // set our URL for working with the api
         query = encodeURIComponent(query);
@@ -243,14 +238,4 @@ TwitchCtrl.prototype.searchGames = function(query, live = false) {
     });
 }
 
-function _buildOptions(options, callback) {
-    callback(Object.keys(options).reduce((params, option, index) => {
-        const encodedParam = `${encodeURIComponent(option)}=${encodeURIComponent(options[option])}`;
-        if(index === 0) {
-            return `?${encodedParam}`;
-        }
-        return `${params}&${encodedParam}`;
-    }, ''));
-}
-
-module.exports = TwitchCtrl;
+module.exports = Twitch;

--- a/src/twitch.js
+++ b/src/twitch.js
@@ -62,7 +62,7 @@ Twitch.prototype.getFeaturedStreams = function(options) {
         // set our URL for working with the api
         let url = "https://api.twitch.tv/kraken/streams/featured"
         if(options) {
-            url += `?${qs.stringify(optionalParams, '&', '=')}`;
+            url += `?${qs.stringify(options, '&', '=')}`;
         }
         // make our request
         this.makeRequest(url)
@@ -90,7 +90,7 @@ Twitch.prototype.getTopStreams = function(options) {
         let url = "https://api.twitch.tv/kraken/streams";
 
         if(options) {
-            url += `?${qs.stringify(optionalParams, '&', '=')}`;
+            url += `?${qs.stringify(options, '&', '=')}`;
         }
             // make our request
             this.makeRequest(url)
@@ -115,7 +115,7 @@ Twitch.prototype.getTopGames = function(options) {
         let url = "https://api.twitch.tv/kraken/games/top";
 
         if(options) {
-            url += `?${qs.stringify(optionalParams, '&', '=')}`;
+            url += `?${qs.stringify(options, '&', '=')}`;
         }
 
         // make our request

--- a/src/twitch.js
+++ b/src/twitch.js
@@ -52,7 +52,7 @@ Twitch.prototype.getUser = function(username) {
 
 /**
 * @description : Gets featured streams
-* @param {Hash} options : optional query params
+* @param {Object} options : optional query params
 * @param {Integer} options.limit : maximum number of objects in array {Default: 25} {Maximum: 100}
 * @param {Integer} options.offset : object offset for pagination {Default: 0}
 * @returns {Promise.<string, Error>} : resolve JSON data or rejects an error
@@ -75,7 +75,7 @@ Twitch.prototype.getFeaturedStreams = function(options) {
 
 /**
 * @description : Makes an api call to retrieve all top streams on twitch
-* @param {Hash} options : optional query params
+* @param {Object} options : optional query params
 * @param {String} options.channel : streams from a comma separated list of channels
 * @param {String} options.game : streams categorized under {game}
 * @param {String} options.language : only shows streams of a certain language. Permitted values are locale ID strings, e.g. {en}, {fi}, {es-mx}
@@ -104,7 +104,7 @@ Twitch.prototype.getTopStreams = function(options) {
 
 /**
 * @description : Makes an API call to top games on twitch
-* @param {Hash} options : optional query params
+* @param {Object} options : optional query params
 * @param {Integer} options.limit : maximum number of objects in array {Default: 25} {Maximum: 100}
 * @param {Integer} options.offset : object offset for pagination {Default: 0}
 * @returns {Promise.<string, Error>} : resolves JSON data or rejects an error


### PR DESCRIPTION
Instead of using _buildOptions I added using the built in node querystring module. I want to run these changes by you before I push anything that could break the module for you. I also renamed the prototype class to just Twitch, and updated the README to include async / await examples.